### PR TITLE
フォームパーツのレイアウト崩れの修正

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -112,7 +112,6 @@
     line-height: 1.4;
     font-size: 16px;
     color: #333;
-    color: #333;
 
     & h1, & h2, & h3, & h4, & h5, & h6 {
         margin-top: 1em;

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -34,6 +34,12 @@
     width: calc(100% - 1rem);
 }
 
+@media (max-width: 768px) {
+    .editor-group {
+        flex-direction: column;
+    }
+}
+
 .output-group {
     display: flex;
     flex-direction: column;
@@ -306,12 +312,26 @@
 .controls {
     padding: 0.5rem 0;
     display: flex;
+    flex-wrap: wrap;
     justify-content: space-between;
     align-items: center;
     flex-shrink: 0;
+    gap: 0.5rem;
+}
+
+@media (max-width: 768px) {
+    .controls {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    
+    .button-group {
+        align-self: flex-end;
+    }
 }
 
 .button-group {
     display: flex;
     gap: 0.5rem;
+    margin-left: auto;
 }

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -18,6 +18,8 @@
     display: flex;
     flex-direction: column;
     min-height: 0;
+    max-height: 100%;
+    overflow: hidden;
 }
 
 .markdown {
@@ -37,6 +39,7 @@
     flex-direction: column;
     gap: 0.5rem;
     height: 100%;
+    overflow: hidden;
 }
 
 .input {
@@ -90,16 +93,19 @@
         border-color: #777;
     }
 }
-
 .output {
     flex: 1;
     overflow-y: auto;
+    overflow-x: auto;
+    overflow-wrap: break-word;
     background-color: #f8f9fa;
     border-radius: 4px;
     padding: 1rem;
     min-height: 0;
+    max-height: calc(100% - 80px); /* ボタンとタイトルの高さを考慮 */
     line-height: 1.4;
     font-size: 16px;
+    color: #333;
     color: #333;
 
     & h1, & h2, & h3, & h4, & h5, & h6 {
@@ -302,6 +308,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    flex-shrink: 0;
 }
 
 .button-group {


### PR DESCRIPTION
## What

- 長文の場合にレイアウトが崩れる問題を修正
- ウィンドウ幅が狭い時に操作しにくい問題を修正

## Why

- 操作性改善

## How

- MediaQueryでサイズ修正・チェックボックス・ボタンのflexコントロールでレイアウト調整
- X方向のoverflowが調整されていなかったので、設定を追加

## Review

メイン業務外なので、お手隙に確認お願いしますmm

## 変更点
通常
![スクリーンショット 2025-03-26 22 07 01](https://github.com/user-attachments/assets/e9042c7f-573e-47a8-9e18-4f8ac7260d03)

やや狭くなった時に、チェックボックスとボタンが縦に並ぶ
![スクリーンショット 2025-03-26 22 07 06](https://github.com/user-attachments/assets/3f477d14-9f8f-43db-9c9c-660fa7799407)

画面幅が狭い時は縦に並べる
![スクリーンショット 2025-03-26 22 07 13](https://github.com/user-attachments/assets/093a5c6c-87cb-46e3-b4df-c884a29a53c8)
